### PR TITLE
Decouple reschedule assessment interval

### DIFF
--- a/README.org
+++ b/README.org
@@ -123,16 +123,18 @@ SCHEDULED: <2024-01-15 Mon .+1d>
 
 *Available CONFIG keys:*
 
-| Key                     | Required | Default       | Description                                        |
-|-------------------------+----------+---------------+----------------------------------------------------|
-| =:window-specs=         | Yes      | -             | List of window specifications (see below)          |
-| =:assessment-interval=  | No       | =(:days 1)=   | How often to re-evaluate                           |
-| =:aggregation-fn=       | No       | min ratio     | Function used to combine multiple window scores    |
-| =:reschedule-interval=  | No       | =(:days 1)=   | Minimum time after completion before rescheduling  |
-| =:reschedule-threshold= | No       | =1.0=         | Conforming ratio threshold for rescheduling        |
-| =:max-reps-per-interval= | No      | =1=           | Max completions counted per assessment interval    |
-| =:only-days=            | No       | (all days)    | Restrict to specific days (e.g., =(:monday :friday)=) |
-| =:from=                 | No       | (unbounded)   | Ignore completions before this date                |
+| Key                               | Required | Default                  | Description                                           |
+|-----------------------------------+----------+--------------------------+-------------------------------------------------------|
+| =:window-specs=                   | Yes      | -                        | List of window specifications (see below)             |
+| =:assessment-interval=            | No       | =(:days 1)=              | How often to re-evaluate streaks and graphs           |
+| =:aggregation-fn=                 | No       | min ratio                | Function used to combine multiple window scores       |
+| =:reschedule-assessment-interval= | No       | =(:days 1)=              | How often to check whether another completion is due  |
+| =:reschedule-interval=            | No       | =(:days 1)=              | Minimum time after completion before rescheduling     |
+| =:reschedule-threshold=           | No       | =1.0=                    | Conforming ratio threshold for rescheduling           |
+| =:reschedule-days=                | No       | =:only-days= or all days | Restrict reminder dates without filtering completions |
+| =:max-reps-per-interval=          | No       | =1=                      | Max completions counted per assessment interval       |
+| =:only-days=                      | No       | (all days)               | Restrict specific completion days                     |
+| =:from=                           | No       | (unbounded)              | Ignore completions before this date                   |
 
 *Window spec format:*
 #+begin_src elisp
@@ -283,17 +285,20 @@ The =OWH_CONFIG= property is the recommended approach. It contains all habit par
 
 For backwards compatibility, you can use individual properties instead of =OWH_CONFIG=:
 
-| Property                           | Default       | Description                                             |
-|------------------------------------+---------------+---------------------------------------------------------|
-| =OWH_WINDOW_DURATION=              | (required)    | Single window length (e.g., =1w=, =1m=, =(:days 7)=)    |
-| =OWH_REPETITIONS_REQUIRED=         | (required)    | Target completions for simple window                    |
-| =OWH_OKAY_REPETITIONS_REQUIRED=    | same as above | Minimum acceptable completions                          |
-| =OWH_WINDOW_SPECS=                 | (alternative) | List of window specs for complex requirements           |
-| =OWH_ASSESSMENT_INTERVAL=          | =(:days 1)=   | How often to re-evaluate (step size for rolling window) |
-| =OWH_RESCHEDULE_INTERVAL=          | =(:days 1)=   | Minimum time after completion before rescheduling       |
-| =OWH_MAX_REPETITIONS_PER_INTERVAL= | =1=           | Cap on completions counted per assessment interval      |
-| =OWH_RESET_TIME=                   | (none)        | Inactive date (e.g., =[2024-01-15]=) to ignore completions before |
-| =OWH_ONLY_DAYS=                    | (none)        | Restrict habit to specific days of week (e.g., M/W/F)   |
+| Property                             | Default                | Description                                             |
+|--------------------------------------+------------------------+---------------------------------------------------------|
+| =OWH_WINDOW_DURATION=                | (required)             | Single window length (e.g., =1w=, =1m=, =(:days 7)=)    |
+| =OWH_REPETITIONS_REQUIRED=           | (required)             | Target completions for simple window                    |
+| =OWH_OKAY_REPETITIONS_REQUIRED=      | same as above          | Minimum acceptable completions                          |
+| =OWH_WINDOW_SPECS=                   | (alternative)          | List of window specs for complex requirements           |
+| =OWH_ASSESSMENT_INTERVAL=            | =(:days 1)=            | How often to re-evaluate streaks and graphs             |
+| =OWH_RESCHEDULE_ASSESSMENT_INTERVAL= | =(:days 1)=            | How often to check whether another completion is due    |
+| =OWH_RESCHEDULE_INTERVAL=            | =(:days 1)=            | Minimum time after completion before rescheduling       |
+| =OWH_RESCHEDULE_THRESHOLD=           | =1.0=                  | Conforming ratio threshold for rescheduling             |
+| =OWH_MAX_REPETITIONS_PER_INTERVAL=   | =1=                    | Cap on completions counted per assessment interval      |
+| =OWH_RESET_TIME=                     | (none)                 | Inactive date to ignore completions before              |
+| =OWH_ONLY_DAYS=                      | (none)                 | Restrict habit to specific days of week (e.g., M/W/F)   |
+| =OWH_RESCHEDULE_DAYS=                | =OWH_ONLY_DAYS= or all | Restrict reminder dates without filtering completions   |
 
 *Note:* When =OWH_CONFIG= is present, scattered properties are ignored. You can migrate existing habits using =M-x org-window-habit-migrate-to-config=.
 
@@ -362,6 +367,23 @@ SCHEDULED: <2024-01-15 Mon .+1d>
 :OWH_CONFIG: (:window-specs ((:duration (:weeks 1 :start :monday) :repetitions 1)) :assessment-interval (:weeks 1 :start :monday))
 :END:
 #+end_src
+
+*Example: Weekly streak with daily catch-up reminders*
+#+begin_src org
+,* TODO Exercise
+SCHEDULED: <2024-01-22 Mon .+1d>
+:PROPERTIES:
+:STYLE: habit
+:OWH_CONFIG: (:window-specs ((:duration (:weeks 1 :start :monday) :repetitions 5))
+             :assessment-interval (:weeks 1 :start :monday)
+             :max-reps-per-interval 5)
+:END:
+#+end_src
+
+This counts streaks by completed Monday-to-Monday weeks. Rescheduling still
+checks daily by default, so after each completion the habit appears again the
+next day until the week has five completions. Once the goal is met, the next
+reminder is the following Monday.
 
 *Example: Sabbath observance (Friday sundown)*
 #+begin_src org

--- a/org-window-habit-computation.el
+++ b/org-window-habit-computation.el
@@ -295,39 +295,45 @@ Searches forward from NOW until the conforming ratio drops below
 reschedule-threshold.  Respects reschedule-days and only-days restrictions."
   (setq now (or now (current-time)))
   (with-slots
-      (window-specs reschedule-interval reschedule-threshold assessment-interval
-                    aggregation-fn done-times only-days reschedule-days)
+      (window-specs reschedule-interval reschedule-threshold
+                    reschedule-assessment-interval aggregation-fn done-times
+                    only-days reschedule-days)
       habit
     (let ((raw-result
            (if (org-window-habit-has-any-done-times habit)
                (cl-loop
-                with start-time =
+                with candidate-time =
                 (org-window-habit-normalize-time-to-duration
                  (org-window-habit-time-max
                   now
-                  (org-window-habit-keyed-duration-add-plist (aref done-times 0)
-                                                             reschedule-interval))
-                 assessment-interval)
-                with iterators =
+                  (org-window-habit-keyed-duration-add-plist
+                   (aref done-times 0)
+                   reschedule-interval))
+                 reschedule-assessment-interval)
+                for iterators =
                 (cl-loop for window-spec in window-specs
                          collect
-                         (org-window-habit-iterator-from-time window-spec start-time))
-                for current-assessment-start = (oref (oref (car iterators) window) assessment-start-time)
+                         (org-window-habit-iterator-from-time
+                          window-spec candidate-time))
                 for conforming-values =
                 (cl-loop for iterator in iterators
-                         collect (org-window-habit-get-conforming-value iterator))
-                for assessment-value = (funcall aggregation-fn conforming-values)
+                         collect
+                         (org-window-habit-get-conforming-value iterator))
+                for assessment-value =
+                (funcall aggregation-fn conforming-values)
                 until (< assessment-value reschedule-threshold)
-                do
-                (cl-loop for iterator in iterators
-                         do (org-window-habit-advance iterator))
-                finally return current-assessment-start)
+                do (setq candidate-time
+                         (org-window-habit-keyed-duration-add-plist
+                          candidate-time
+                          reschedule-assessment-interval))
+                finally return candidate-time)
              (org-window-habit-normalize-time-to-duration
-              now assessment-interval))))
+              now reschedule-assessment-interval))))
       ;; Snap to next allowed reschedule day
       (org-window-habit-next-allowed-day
        raw-result
-       (org-window-habit-effective-reschedule-days only-days reschedule-days)))))
+       (org-window-habit-effective-reschedule-days
+        only-days reschedule-days)))))
 
 (cl-defmethod org-window-habit-get-future-required-intervals
   ((habit org-window-habit) count &optional now)
@@ -344,9 +350,10 @@ Each interval is computed by:
 This enables prospective planning: showing future \"must complete by\" dates
 assuming you complete at the last possible moment each time."
   (setq now (or now (current-time)))
-  (with-slots (window-specs assessment-interval reschedule-interval
-                            reschedule-threshold max-repetitions-per-interval
-                            aggregation-fn only-days reschedule-days start-time)
+  (with-slots (window-specs assessment-interval reschedule-assessment-interval
+                            reschedule-interval reschedule-threshold
+                            max-repetitions-per-interval aggregation-fn only-days
+                            reschedule-days start-time)
       habit
     (let ((result '())
           ;; Copy done-times to a list we can extend with simulated completions
@@ -366,6 +373,8 @@ assuming you complete at the last possible moment each time."
               (temp-habit (make-instance 'org-window-habit
                                          :window-specs copied-specs
                                          :assessment-interval assessment-interval
+                                         :reschedule-assessment-interval
+                                         reschedule-assessment-interval
                                          :reschedule-interval reschedule-interval
                                          :reschedule-threshold reschedule-threshold
                                          :max-repetitions-per-interval max-repetitions-per-interval

--- a/org-window-habit-config.el
+++ b/org-window-habit-config.el
@@ -198,6 +198,17 @@ A time exactly at a config's :from belongs to that config."
   (or (plist-get config :assessment-interval)
       '(:days 1)))
 
+(defun org-window-habit-config-get-reschedule-interval (config)
+  "Get reschedule-interval from CONFIG, defaulting to (:days 1)."
+  (or (plist-get config :reschedule-interval)
+      '(:days 1)))
+
+(defun org-window-habit-config-get-reschedule-assessment-interval (config)
+  "Get reschedule-assessment-interval from CONFIG.
+Defaults to (:days 1)."
+  (or (plist-get config :reschedule-assessment-interval)
+      '(:days 1)))
+
 (defun org-window-habit-config-get-max-reps-per-interval (config)
   "Get max-reps-per-interval from CONFIG, defaulting to 1 if not set."
   (or (plist-get config :max-reps-per-interval) 1))
@@ -219,9 +230,10 @@ Returns nil if the oldest config has no :from (unbounded past)."
 (defun org-window-habit-migrate-to-config ()
   "Migrate current habit's scattered properties to unified CONFIG property.
 Reads WINDOW_DURATION/REPETITIONS_REQUIRED or WINDOW_SPECS,
-ASSESSMENT_INTERVAL, RESCHEDULE_INTERVAL, MAX_REPETITIONS_PER_INTERVAL,
-ONLY_DAYS, and RESET_TIME properties, builds a unified config plist,
-and writes it to the CONFIG property.
+ASSESSMENT_INTERVAL, RESCHEDULE_ASSESSMENT_INTERVAL, RESCHEDULE_INTERVAL,
+RESCHEDULE_THRESHOLD, MAX_REPETITIONS_PER_INTERVAL, ONLY_DAYS,
+RESCHEDULE_DAYS, and RESET_TIME properties, builds a unified config
+plist, and writes it to the CONFIG property.
 
 If RESET_TIME exists, it's converted to :from on the config."
   (interactive)
@@ -229,9 +241,16 @@ If RESET_TIME exists, it's converted to :from on the config."
          (window-duration (org-entry-get nil (org-window-habit-property "WINDOW_DURATION") t))
          (reps-required (org-entry-get nil (org-window-habit-property "REPETITIONS_REQUIRED") t))
          (assessment-str (org-entry-get nil (org-window-habit-property "ASSESSMENT_INTERVAL") t))
+         (reschedule-assessment-str
+          (org-entry-get
+           nil (org-window-habit-property "RESCHEDULE_ASSESSMENT_INTERVAL") t))
          (reschedule-str (org-entry-get nil (org-window-habit-property "RESCHEDULE_INTERVAL") t))
+         (reschedule-threshold-str
+          (org-entry-get nil (org-window-habit-property "RESCHEDULE_THRESHOLD") t))
          (max-reps-str (org-entry-get nil (org-window-habit-property "MAX_REPETITIONS_PER_INTERVAL") t))
          (only-days-str (org-entry-get nil (org-window-habit-property "ONLY_DAYS") t))
+         (reschedule-days-str
+          (org-entry-get nil (org-window-habit-property "RESCHEDULE_DAYS") t))
          (reset-time-str (org-entry-get nil (org-window-habit-property "RESET_TIME")))
          ;; Build window-specs list
          (window-specs
@@ -249,15 +268,28 @@ If RESET_TIME exists, it's converted to :from on the config."
     (when assessment-str
       (setq config (plist-put config :assessment-interval
                               (org-window-habit-string-duration-to-plist assessment-str))))
+    (when reschedule-assessment-str
+      (setq config
+            (plist-put
+             config :reschedule-assessment-interval
+             (org-window-habit-string-duration-to-plist
+              reschedule-assessment-str))))
     (when reschedule-str
       (setq config (plist-put config :reschedule-interval
                               (org-window-habit-string-duration-to-plist reschedule-str))))
+    (when reschedule-threshold-str
+      (setq config (plist-put config :reschedule-threshold
+                              (string-to-number reschedule-threshold-str))))
     (when max-reps-str
       (setq config (plist-put config :max-reps-per-interval
                               (string-to-number max-reps-str))))
     (when only-days-str
       (setq config (plist-put config :only-days
                               (car (read-from-string only-days-str)))))
+    (when reschedule-days-str
+      (setq config (plist-put config :reschedule-days
+                              (car (read-from-string
+                                    reschedule-days-str)))))
     ;; Convert RESET_TIME to :from
     (when reset-time-str
       (setq config (plist-put config :from reset-time-str)))

--- a/org-window-habit-core.el
+++ b/org-window-habit-core.el
@@ -75,6 +75,11 @@ Numeric VALUE entries are treated as weights; non-numeric values default to 1.0.
    (assessment-interval
     :initarg :assessment-interval :initform '(:days 1)
     :documentation "Duration plist for how often to re-evaluate conformity (step size for rolling window).")
+   (reschedule-assessment-interval
+    :initarg :reschedule-assessment-interval :initform nil
+    :documentation "Duration plist for reschedule checks.
+When nil, defaults to (:days 1). This lets reminders use a
+different cadence than streak and graph assessment.")
    (reschedule-interval
     :initarg :reschedule-interval :initform '(:days 1)
     :documentation "Minimum time after completion before the habit can be rescheduled.")
@@ -89,6 +94,9 @@ Default 1.0 means reschedule as soon as not fully conforming.")
    (assessment-decrement-plist
     :initarg :assessment-decrement-plist :initform nil
     :documentation "Negated assessment-interval, used for iterating backwards through time.")
+   (reschedule-assessment-decrement-plist
+    :initarg :reschedule-assessment-decrement-plist :initform nil
+    :documentation "Negated reschedule-assessment-interval.")
    (max-repetitions-per-interval
     :initarg :max-repetitions-per-interval :initform 1
     :documentation "Maximum completions counted per assessment interval.
@@ -203,10 +211,16 @@ Validates required properties and sets up defaults."
   (when (null (oref habit window-specs))
     (error "Habits must define at least one window when org-window-habit is enabled"))
   (when (null (oref habit reschedule-interval))
-    (oset habit reschedule-interval (oref habit assessment-interval)))
+    (oset habit reschedule-interval '(:days 1)))
+  (when (null (oref habit reschedule-assessment-interval))
+    (oset habit reschedule-assessment-interval '(:days 1)))
   (when (null (oref habit assessment-decrement-plist))
     (oset habit assessment-decrement-plist
           (org-window-habit-negate-plist (oref habit assessment-interval))))
+  (when (null (oref habit reschedule-assessment-decrement-plist))
+    (oset habit reschedule-assessment-decrement-plist
+          (org-window-habit-negate-plist
+           (oref habit reschedule-assessment-interval))))
   (when (null (oref habit start-time))
     (oset habit start-time
           (org-window-habit-normalize-time-to-duration

--- a/org-window-habit-instance.el
+++ b/org-window-habit-instance.el
@@ -73,21 +73,31 @@ CONFIG-STR is the value of the CONFIG property (single or versioned config)."
                                                'org-window-habit-window-spec args)))
          (assessment-interval (or (plist-get current-config :assessment-interval)
                                   '(:days 1)))
+         (reschedule-interval
+          (org-window-habit-config-get-reschedule-interval current-config))
+         (reschedule-assessment-interval
+          (org-window-habit-config-get-reschedule-assessment-interval
+           current-config))
          (aggregation-fn (or (plist-get current-config :aggregation-fn)
                              'org-window-habit-default-aggregation-fn))
-         (reschedule-interval (plist-get current-config :reschedule-interval))
+         (reschedule-threshold
+          (or (plist-get current-config :reschedule-threshold) 1.0))
          (max-reps (or (plist-get current-config :max-reps-per-interval) 1))
          (only-days (plist-get current-config :only-days))
+         (reschedule-days (plist-get current-config :reschedule-days))
          ;; :from on single config acts like reset-time
          (reset-time (plist-get current-config :from)))
     (make-instance 'org-window-habit
                    :start-time nil
                    :reset-time reset-time
                    :only-days only-days
+                   :reschedule-days reschedule-days
                    :window-specs window-specs
                    :assessment-interval assessment-interval
+                   :reschedule-assessment-interval reschedule-assessment-interval
                    :aggregation-fn aggregation-fn
                    :reschedule-interval reschedule-interval
+                   :reschedule-threshold reschedule-threshold
                    :done-times done-times-vector
                    :max-repetitions-per-interval max-reps
                    :configs configs)))
@@ -104,7 +114,20 @@ Also builds and stores a config plist in the configs slot for uniformity."
          (reschedule-interval-str
           (org-entry-get nil (org-window-habit-property "RESCHEDULE_INTERVAL")))
          (reschedule-interval
-          (org-window-habit-string-duration-to-plist reschedule-interval-str))
+          (org-window-habit-string-duration-to-plist
+           reschedule-interval-str :default '(:days 1)))
+         (reschedule-assessment-interval-str
+          (org-entry-get
+           nil (org-window-habit-property "RESCHEDULE_ASSESSMENT_INTERVAL")))
+         (reschedule-assessment-interval
+          (org-window-habit-string-duration-to-plist
+           reschedule-assessment-interval-str :default '(:days 1)))
+         (reschedule-threshold-str
+          (org-entry-get nil (org-window-habit-property "RESCHEDULE_THRESHOLD")))
+         (reschedule-threshold
+          (if reschedule-threshold-str
+              (string-to-number reschedule-threshold-str)
+            1.0))
          (max-reps-str
           (org-entry-get nil (org-window-habit-property "MAX_REPETITIONS_PER_INTERVAL") t))
          (max-repetitions-per-interval
@@ -118,6 +141,10 @@ Also builds and stores a config plist in the configs slot for uniformity."
           (org-entry-get nil (org-window-habit-property "ONLY_DAYS")))
          (only-days
           (org-window-habit-parse-only-days only-days-str))
+         (reschedule-days-str
+          (org-entry-get nil (org-window-habit-property "RESCHEDULE_DAYS")))
+         (reschedule-days
+          (org-window-habit-parse-only-days reschedule-days-str))
          (window-specs-objects
           (or (org-window-habit-create-specs)
               (org-window-habit-create-specs-from-perfect-okay)))
@@ -132,15 +159,27 @@ Also builds and stores a config plist in the configs slot for uniformity."
               (setq c (plist-put c :assessment-interval
                                  (org-window-habit-string-duration-to-plist
                                   assessment-interval-str))))
+            ;; Only add :reschedule-assessment-interval if explicitly set
+            (when reschedule-assessment-interval-str
+              (setq c (plist-put
+                       c :reschedule-assessment-interval
+                       reschedule-assessment-interval)))
             ;; Only add :reschedule-interval if explicitly set
             (when reschedule-interval-str
               (setq c (plist-put c :reschedule-interval reschedule-interval)))
+            ;; Only add :reschedule-threshold if explicitly set
+            (when reschedule-threshold-str
+              (setq c (plist-put c :reschedule-threshold
+                                 reschedule-threshold)))
             ;; Only add :max-reps-per-interval if explicitly set (and not "1")
             (when (and max-reps-str (not (string= max-reps-str "1")))
               (setq c (plist-put c :max-reps-per-interval max-repetitions-per-interval)))
             ;; Only add :only-days if set
             (when only-days
               (setq c (plist-put c :only-days only-days)))
+            ;; Only add :reschedule-days if set
+            (when reschedule-days
+              (setq c (plist-put c :reschedule-days reschedule-days)))
             ;; Convert RESET_TIME to :from
             (when reset-time
               (setq c (plist-put c :from reset-time)))
@@ -149,9 +188,12 @@ Also builds and stores a config plist in the configs slot for uniformity."
                    :start-time nil
                    :reset-time reset-time
                    :only-days only-days
+                   :reschedule-days reschedule-days
                    :window-specs window-specs-objects
                    :assessment-interval assessment-interval
+                   :reschedule-assessment-interval reschedule-assessment-interval
                    :reschedule-interval reschedule-interval
+                   :reschedule-threshold reschedule-threshold
                    :done-times done-times-vector
                    :max-repetitions-per-interval max-repetitions-per-interval
                    :configs (list config))))

--- a/test/org-window-habit-test.el
+++ b/test/org-window-habit-test.el
@@ -1015,7 +1015,7 @@ This tests backwards compatibility - both old formats work."
                   :start-time nil)))
 
 (ert-deftest owh-test-habit-sets-reschedule-interval-default ()
-  "Test that reschedule-interval defaults to assessment-interval."
+  "Test that reschedule-interval defaults to one day."
   (let* ((spec (make-instance 'org-window-habit-window-spec))
          (habit (make-instance 'org-window-habit
                                :window-specs (list spec)
@@ -1023,7 +1023,20 @@ This tests backwards compatibility - both old formats work."
                                :reschedule-interval nil
                                :done-times []
                                :start-time nil)))
-    (should (equal (oref habit reschedule-interval) '(:days 2)))))
+    (should (equal (oref habit reschedule-interval) '(:days 1)))))
+
+(ert-deftest owh-test-habit-sets-reschedule-assessment-default ()
+  "Test that reschedule-assessment-interval defaults to one day."
+  (let* ((spec (make-instance 'org-window-habit-window-spec))
+         (habit (make-instance 'org-window-habit
+                               :window-specs (list spec)
+                               :assessment-interval '(:weeks 1 :start :monday)
+                               :reschedule-interval '(:days 2)
+                               :reschedule-assessment-interval nil
+                               :done-times []
+                               :start-time nil)))
+    (should (equal (oref habit reschedule-assessment-interval)
+                   '(:days 1)))))
 
 (ert-deftest owh-test-habit-links-window-specs ()
   "Test that habit initialization links window-specs back to habit."
@@ -1784,6 +1797,67 @@ Use explicit start-time to avoid window scaling."
     (should (org-window-habit-time-greater-p
              next-required
              (owh-test-make-time 2024 1 15)))))
+
+(ert-deftest owh-test-default-rescheduling-decouples-weekly-streak ()
+  "Daily rescheduling is the default for weekly streak assessment."
+  (let* ((spec (make-instance 'org-window-habit-window-spec
+                              :duration '(:weeks 1 :start :monday)
+                              :repetitions 5))
+         (monday (owh-test-make-time 2024 1 22 10 0 0))
+         (tuesday (owh-test-make-time 2024 1 23 10 0 0))
+         (wednesday (owh-test-make-time 2024 1 24 10 0 0))
+         (thursday (owh-test-make-time 2024 1 25 10 0 0))
+         (friday (owh-test-make-time 2024 1 26 10 0 0))
+         (habit (make-instance
+                 'org-window-habit
+                 :window-specs (list spec)
+                 :assessment-interval '(:weeks 1 :start :monday)
+                 :max-repetitions-per-interval 5
+                 :done-times (vector tuesday monday)
+                 :start-time (owh-test-make-time 2024 1 22 0 0 0))))
+    (should
+     (owh-test-times-equal-p
+      (org-window-habit-get-next-required-interval
+       habit (owh-test-make-time 2024 1 23 12 0 0))
+      (owh-test-make-time 2024 1 24 0 0 0)))
+    (oset habit done-times (vector wednesday tuesday monday))
+    (should
+     (owh-test-times-equal-p
+      (org-window-habit-get-next-required-interval
+       habit (owh-test-make-time 2024 1 24 12 0 0))
+      (owh-test-make-time 2024 1 25 0 0 0)))
+    (oset habit done-times (vector friday thursday wednesday tuesday monday))
+    (should
+     (owh-test-times-equal-p
+      (org-window-habit-get-next-required-interval
+       habit (owh-test-make-time 2024 1 26 12 0 0))
+      (owh-test-make-time 2024 1 29 0 0 0)))
+    (should (= (org-window-habit-current-streak
+                habit (owh-test-make-time 2024 1 26 12 0 0))
+               1))))
+
+(ert-deftest owh-test-reschedule-assessment-interval-explicit-override ()
+  "Explicit reschedule-assessment-interval overrides the daily default."
+  (let* ((spec (make-instance 'org-window-habit-window-spec
+                              :duration '(:weeks 1 :start :monday)
+                              :repetitions 5))
+         (monday (owh-test-make-time 2024 1 22 10 0 0))
+         (tuesday (owh-test-make-time 2024 1 23 10 0 0))
+         (habit (make-instance
+                 'org-window-habit
+                 :window-specs (list spec)
+                 :assessment-interval '(:weeks 1 :start :monday)
+                 :reschedule-assessment-interval
+                 '(:weeks 1 :start :monday)
+                 :reschedule-interval '(:days 1)
+                 :max-repetitions-per-interval 5
+                 :done-times (vector tuesday monday)
+                 :start-time (owh-test-make-time 2024 1 22 0 0 0))))
+    (should
+     (owh-test-times-equal-p
+      (org-window-habit-get-next-required-interval
+       habit (owh-test-make-time 2024 1 23 12 0 0))
+      (owh-test-make-time 2024 1 22 0 0 0)))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Scenario: Complex Multi-Spec Habit (Fitness tracking)
@@ -3539,6 +3613,32 @@ prevents scheduling too soon after a completion."
              (nth 0 intervals)
              (owh-test-make-time 2024 1 17 0 0 0)))))
 
+(ert-deftest owh-test-future-intervals-default-weekly-catch-up ()
+  "Future intervals use daily catch-up by default for weekly quotas."
+  (let* ((spec (make-instance 'org-window-habit-window-spec
+                              :duration '(:weeks 1 :start :monday)
+                              :repetitions 5))
+         (monday (owh-test-make-time 2024 1 22 10 0 0))
+         (tuesday (owh-test-make-time 2024 1 23 10 0 0))
+         (habit (make-instance
+                 'org-window-habit
+                 :window-specs (list spec)
+                 :assessment-interval '(:weeks 1 :start :monday)
+                 :max-repetitions-per-interval 5
+                 :done-times (vector tuesday monday)
+                 :start-time (owh-test-make-time 2024 1 22 0 0 0)))
+         (intervals (org-window-habit-get-future-required-intervals
+                     habit 3 (owh-test-make-time 2024 1 23 12 0 0))))
+    (should (owh-test-times-equal-p
+             (nth 0 intervals)
+             (owh-test-make-time 2024 1 24 0 0 0)))
+    (should (owh-test-times-equal-p
+             (nth 1 intervals)
+             (owh-test-make-time 2024 1 25 0 0 0)))
+    (should (owh-test-times-equal-p
+             (nth 2 intervals)
+             (owh-test-make-time 2024 1 26 0 0 0)))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Edge Case: Max Repetitions Per Interval
 ;;; ---------------------------------------------------------------------------
@@ -4212,18 +4312,22 @@ returns nil, allowing callers to filter those completions."
   "Test that a config can contain all habit parameters."
   (let ((config-str "(:window-specs ((:duration (:days 7) :repetitions 3))
                      :assessment-interval (:days 2)
+                     :reschedule-assessment-interval (:days 1)
                      :reschedule-interval (:days 1)
                      :reschedule-threshold 0.8
                      :max-reps-per-interval 2
                      :only-days (:monday :wednesday :friday)
+                     :reschedule-days (:monday :friday)
                      :aggregation-fn org-window-habit-default-aggregation-fn)"))
     (let* ((configs (org-window-habit-parse-config config-str))
            (config (car configs)))
       (should (equal (plist-get config :assessment-interval) '(:days 2)))
+      (should (equal (plist-get config :reschedule-assessment-interval) '(:days 1)))
       (should (equal (plist-get config :reschedule-interval) '(:days 1)))
       (should (= (plist-get config :reschedule-threshold) 0.8))
       (should (= (plist-get config :max-reps-per-interval) 2))
       (should (equal (plist-get config :only-days) '(:monday :wednesday :friday)))
+      (should (equal (plist-get config :reschedule-days) '(:monday :friday)))
       (should (eq (plist-get config :aggregation-fn) 'org-window-habit-default-aggregation-fn)))))
 
 (ert-deftest owh-test-versioned-configs-different-assessment-intervals ()
@@ -4335,6 +4439,64 @@ returns nil, allowing callers to filter those completions."
       (should (null (plist-get config :reschedule-threshold)))
       (should (= (org-window-habit-config-get-reschedule-threshold config) 1.0)))))
 
+(ert-deftest owh-test-config-defaults-reschedule-assessment-interval ()
+  "Missing reschedule-assessment-interval defaults to one day."
+  (let ((config-str "(:window-specs ((:duration (:days 7) :repetitions 3))
+                     :assessment-interval (:weeks 1 :start :monday)
+                     :reschedule-interval (:days 2))"))
+    (let* ((configs (org-window-habit-parse-config config-str))
+           (config (car configs)))
+      (should (null (plist-get config :reschedule-assessment-interval)))
+      (should
+       (equal
+        (org-window-habit-config-get-reschedule-assessment-interval config)
+        '(:days 1))))))
+
+(ert-deftest owh-test-config-defaults-reschedule-interval ()
+  "Missing reschedule-interval defaults to one day."
+  (let ((config-str "(:window-specs ((:duration (:days 7) :repetitions 3))
+                     :assessment-interval (:weeks 1 :start :monday))"))
+    (let* ((configs (org-window-habit-parse-config config-str))
+           (config (car configs)))
+      (should (null (plist-get config :reschedule-interval)))
+      (should (equal (org-window-habit-config-get-reschedule-interval config)
+                     '(:days 1)))
+      (should
+       (equal
+        (org-window-habit-config-get-reschedule-assessment-interval config)
+        '(:days 1))))))
+
+(ert-deftest owh-test-create-instance-from-config-default-rescheduling ()
+  "CONFIG habits default to daily rescheduling even with weekly assessment."
+  (let* ((config-str "(:window-specs ((:duration (:weeks 1 :start :monday)
+                                      :repetitions 5))
+                     :assessment-interval (:weeks 1 :start :monday)
+                     :max-reps-per-interval 5)")
+         (habit (org-window-habit-create-instance-from-config config-str [])))
+    (should (equal (oref habit assessment-interval)
+                   '(:weeks 1 :start :monday)))
+    (should (equal (oref habit reschedule-interval) '(:days 1)))
+    (should (equal (oref habit reschedule-assessment-interval)
+                   '(:days 1)))))
+
+(ert-deftest owh-test-create-instance-from-config-reschedule-options ()
+  "CONFIG reschedule options are passed into habit instances."
+  (let* ((config-str "(:window-specs ((:duration (:days 7) :repetitions 3))
+                     :assessment-interval (:weeks 1 :start :monday)
+                     :reschedule-assessment-interval (:days 1)
+                     :reschedule-interval (:days 1)
+                     :reschedule-threshold 0.8
+                     :reschedule-days (:monday :wednesday :friday))")
+         (habit (org-window-habit-create-instance-from-config config-str [])))
+    (should (equal (oref habit assessment-interval)
+                   '(:weeks 1 :start :monday)))
+    (should (equal (oref habit reschedule-assessment-interval)
+                   '(:days 1)))
+    (should (equal (oref habit reschedule-interval) '(:days 1)))
+    (should (= (oref habit reschedule-threshold) 0.8))
+    (should (equal (oref habit reschedule-days)
+                   '(:monday :wednesday :friday)))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Versioned Config: Scattered Properties Conversion
 ;;; ---------------------------------------------------------------------------
@@ -4349,9 +4511,12 @@ returns nil, allowing callers to filter those completions."
       (insert ":WINDOW_DURATION: 7d\n")
       (insert ":REPETITIONS_REQUIRED: 3\n")
       (insert ":ASSESSMENT_INTERVAL: (:days 2)\n")
+      (insert ":RESCHEDULE_ASSESSMENT_INTERVAL: (:days 1)\n")
       (insert ":RESCHEDULE_INTERVAL: (:days 1)\n")
+      (insert ":RESCHEDULE_THRESHOLD: 0.8\n")
       (insert ":MAX_REPETITIONS_PER_INTERVAL: 2\n")
       (insert ":ONLY_DAYS: (:monday :wednesday :friday)\n")
+      (insert ":RESCHEDULE_DAYS: (:monday :friday)\n")
       (insert ":RESET_TIME: [2024-06-01]\n")
       (insert ":END:\n")
       (insert ":LOGBOOK:\n")
@@ -4365,9 +4530,14 @@ returns nil, allowing callers to filter those completions."
           ;; All properties should be in the config
           (should (plist-get config :window-specs))
           (should (equal (plist-get config :assessment-interval) '(:days 2)))
+          (should (equal (plist-get config :reschedule-assessment-interval)
+                         '(:days 1)))
           (should (equal (plist-get config :reschedule-interval) '(:days 1)))
+          (should (= (plist-get config :reschedule-threshold) 0.8))
           (should (= (plist-get config :max-reps-per-interval) 2))
           (should (equal (plist-get config :only-days) '(:monday :wednesday :friday)))
+          (should (equal (plist-get config :reschedule-days)
+                         '(:monday :friday)))
           ;; RESET_TIME should become :from
           (should (owh-test-times-equal-p (plist-get config :from)
                                           (owh-test-make-time 2024 6 1))))))))
@@ -4394,6 +4564,29 @@ returns nil, allowing callers to filter those completions."
           ;; Optional fields should be nil (defaults applied at usage time)
           (should (null (plist-get config :assessment-interval)))
           (should (null (plist-get config :from))))))))
+
+(ert-deftest owh-test-scattered-properties-default-daily-rescheduling ()
+  "Scattered properties default to daily rescheduling for weekly assessment."
+  (let ((org-window-habit-property-prefix nil))
+    (with-temp-buffer
+      (org-mode)
+      (insert "* TODO Test habit\n")
+      (insert ":PROPERTIES:\n")
+      (insert ":WINDOW_SPECS: ((:duration (:weeks 1 :start :monday) :repetitions 5))\n")
+      (insert ":ASSESSMENT_INTERVAL: (:weeks 1 :start :monday)\n")
+      (insert ":MAX_REPETITIONS_PER_INTERVAL: 5\n")
+      (insert ":END:\n")
+      (goto-char (point-min))
+      (let ((habit (org-window-habit-create-instance-from-heading-at-point)))
+        (should (equal (oref habit assessment-interval)
+                       '(:weeks 1 :start :monday)))
+        (should (equal (oref habit reschedule-interval) '(:days 1)))
+        (should (equal (oref habit reschedule-assessment-interval)
+                       '(:days 1)))
+        (let ((config (car (oref habit configs))))
+          (should (null (plist-get config :reschedule-interval)))
+          (should (null (plist-get config
+                                   :reschedule-assessment-interval))))))))
 
 ;;; ---------------------------------------------------------------------------
 ;;; Versioned Config: No Separate reset-time Slot


### PR DESCRIPTION
## Summary
- make rescheduling check daily by default while preserving weekly/monthly assessment intervals for streaks and graphs
- evaluate reminder due-ness against the real assessment window, so weekly quota habits reschedule tomorrow until the current week target is met
- keep `:reschedule-assessment-interval` as an advanced override for non-daily reminder checks
- wire reschedule cadence, threshold, and day restrictions through CONFIG and legacy scattered properties
- document the default weekly-streak/daily-catch-up behavior

## Validation
- `just test`
- `just check`