### PR TITLE
Honor inactive versioned config ranges at runtime

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3,7 +3,16 @@
 All notable changes to org-window-habit are documented in this file.
 
 ** Unreleased
-- No changes yet.
+
+*** Added
+- Runtime helpers to test habit activity and materialize the config active at a
+  reference time
+
+*** Fixed
+- Respect versioned CONFIG =:from=/=:until= ranges during evaluation, including
+  inactive gaps and bounded single configs
+- Avoid conformity, streak, next-required, graph-reminder, and auto-repeat
+  results for inactive habits
 
 ** 2026-02-04 (v0.1.3)
 

--- a/README.org
+++ b/README.org
@@ -134,7 +134,8 @@ SCHEDULED: <2024-01-15 Mon .+1d>
 | =:reschedule-days=                | No       | =:only-days= or all days | Restrict reminder dates without filtering completions |
 | =:max-reps-per-interval=          | No       | =1=                      | Max completions counted per assessment interval       |
 | =:only-days=                      | No       | (all days)               | Restrict specific completion days                     |
-| =:from=                           | No       | (unbounded)              | Ignore completions before this date                   |
+| =:from=                           | No       | (unbounded)              | Start requiring the habit at this inclusive date      |
+| =:until=                          | No       | (unbounded)              | Stop requiring the habit at this exclusive date       |
 
 *Window spec format:*
 #+begin_src elisp
@@ -162,16 +163,28 @@ This defines:
 
 *Versioned config rules:*
 1. Configs are listed in *reverse temporal order* (most recent first)
-2. The first config has no =:until= (active now and forever)
-3. Each config's =:from= is implicitly the previous config's =:until=
-4. An explicit =:from= on a config creates a *gap* where the habit is inactive
+2. Each config is active over the half-open range =[from, until)=
+3. =:from= is inclusive; =:until= is exclusive; omitted bounds are unbounded
+4. Matching adjacent bounds produce a continuous rule change; a gap between
+   bounds makes the habit inactive during that period
 
 *With a gap (habit pause):*
 #+begin_src org
-:OWH_CONFIG: ((:window-specs ((:duration (:days 7) :repetitions 5))) (:until "2024-06-01" :from "2024-01-01" :window-specs ((:duration (:days 7) :repetitions 3))))
+:OWH_CONFIG: ((:from "2024-09-01" :window-specs ((:duration (:days 7) :repetitions 5))) (:until "2024-06-01" :window-specs ((:duration (:days 7) :repetitions 3))))
 #+end_src
 
-This habit was inactive before January 1, 2024 (the =:from= on the oldest config acts like a reset time).
+This habit was inactive from June 1 through August 31, then resumed on
+September 1.  A single config with =:until= and no later version represents a
+habit that remains inactive after that date.
+
+At runtime, =org-window-habit-create-instance-from-heading-at-point= and
+=org-window-habit-create-instance-from-config= accept an optional reference
+time and return nil when no config is active then.
+=org-window-habit-active-at-time-p= tests an existing instance, while
+=org-window-habit-for-time= returns an instance materialized with the version
+active at the requested time or nil for a gap.  Status and scheduling APIs use
+the same behavior and return nil rather than a conformity or requirement for an
+inactive habit.
 
 *** Legacy: Scattered Properties
 

--- a/org-window-habit-advice.el
+++ b/org-window-habit-advice.el
@@ -67,21 +67,23 @@ ORIG is the original function, ARGS are its arguments."
 (defun org-window-habit-auto-repeat (&rest _args)
   "Reassign the date of the habit to the next day at which it is required."
   (interactive)
-  (let* ((required-interval-start
-          (org-window-habit-get-next-required-interval
-           (org-window-habit-create-instance-from-heading-at-point)))
-         (repeat (org-get-repeat))
-         (target-time-string
-          (format-time-string (car org-time-stamp-formats)
-                              required-interval-start)))
-    (when org-window-habit-repeat-to-deadline
-      (org-deadline nil target-time-string)
-      (when (null repeat)
-        (org-window-habit-add-repeater ".+1d")))
-    (when org-window-habit-repeat-to-scheduled
-      (org-schedule nil target-time-string)
-      (when (null repeat)
-        (org-window-habit-add-repeater ".+1d")))))
+  (let* ((habit (org-window-habit-create-instance-from-heading-at-point))
+         (required-interval-start
+          (when habit
+            (org-window-habit-get-next-required-interval habit))))
+    (when required-interval-start
+      (let ((repeat (org-get-repeat))
+            (target-time-string
+             (format-time-string (car org-time-stamp-formats)
+                                 required-interval-start)))
+        (when org-window-habit-repeat-to-deadline
+          (org-deadline nil target-time-string)
+          (when (null repeat)
+            (org-window-habit-add-repeater ".+1d")))
+        (when org-window-habit-repeat-to-scheduled
+          (org-schedule nil target-time-string)
+          (when (null repeat)
+            (org-window-habit-add-repeater ".+1d")))))))
 
 (defun org-window-habit-add-repeater (repeater)
   "Add REPEATER string to the last inserted timestamp."

--- a/org-window-habit-computation.el
+++ b/org-window-habit-computation.el
@@ -255,35 +255,41 @@ ARGS are passed to the conforming ratio calculation."
 TIME defaults to the current time.  THRESHOLD defaults to 1.0.
 The current interval counts if its aggregate conforming ratio is at
 least THRESHOLD, and the scan continues backward until the first
-non-conforming interval or HABIT's effective start."
+non-conforming interval or the active config's start.  Return nil when
+HABIT is inactive at TIME."
   (setq time (or time (current-time)))
   (setq threshold (or threshold 1.0))
-  (if (not (org-window-habit-has-any-done-times habit))
-      0
-    (with-slots (window-specs assessment-decrement-plist start-time) habit
-      (let ((iterators
-             (cl-loop for window-spec in window-specs
-                      collect
-                      (org-window-habit-iterator-from-time window-spec time)))
-            (streak-start-time
-             (or (org-window-habit-get-effective-start habit) start-time))
-            (streak 0)
-            (keep-scanning t))
-        (while keep-scanning
-          (let* ((window (oref (car iterators) window))
-                 (assessment-end (oref window assessment-end-time)))
-            (if (not (time-less-p streak-start-time assessment-end))
-                (setq keep-scanning nil)
-              (let ((assessment-value
-                     (org-window-habit-assess-interval habit iterators)))
-                (if (>= assessment-value threshold)
-                    (progn
-                      (cl-incf streak)
-                      (cl-loop for iterator in iterators
-                               do (org-window-habit-advance
-                                   iterator :amount assessment-decrement-plist)))
-                  (setq keep-scanning nil))))))
-        streak))))
+  (let ((active-habit (org-window-habit-for-time habit time)))
+    (cond
+     ((null active-habit) nil)
+     ((not (eq active-habit habit))
+      (org-window-habit-current-streak active-habit time threshold))
+     ((not (org-window-habit-has-any-done-times habit)) 0)
+     (t
+      (with-slots (window-specs assessment-decrement-plist start-time) habit
+        (let ((iterators
+               (cl-loop for window-spec in window-specs
+                        collect
+                        (org-window-habit-iterator-from-time window-spec time)))
+              (streak-start-time
+               (or (plist-get (oref habit active-config) :from) start-time))
+              (streak 0)
+              (keep-scanning t))
+          (while keep-scanning
+            (let* ((window (oref (car iterators) window))
+                   (assessment-end (oref window assessment-end-time)))
+              (if (not (time-less-p streak-start-time assessment-end))
+                  (setq keep-scanning nil)
+                (let ((assessment-value
+                       (org-window-habit-assess-interval habit iterators)))
+                  (if (>= assessment-value threshold)
+                      (progn
+                        (cl-incf streak)
+                        (cl-loop for iterator in iterators
+                                 do (org-window-habit-advance
+                                     iterator :amount assessment-decrement-plist)))
+                    (setq keep-scanning nil))))))
+          streak))))))
 
 
 ;;; Next required interval
@@ -292,48 +298,68 @@ non-conforming interval or HABIT's effective start."
   ((habit org-window-habit) &optional now)
   "Find the next time when HABIT will need a completion.
 Searches forward from NOW until the conforming ratio drops below
-reschedule-threshold.  Respects reschedule-days and only-days restrictions."
+reschedule-threshold.  Respects reschedule-days and only-days restrictions.
+Return nil when HABIT is inactive at NOW or becomes inactive before a
+completion is required."
   (setq now (or now (current-time)))
-  (with-slots
-      (window-specs reschedule-interval reschedule-threshold
-                    reschedule-assessment-interval aggregation-fn done-times
-                    only-days reschedule-days)
-      habit
-    (let ((raw-result
-           (if (org-window-habit-has-any-done-times habit)
-               (cl-loop
-                with candidate-time =
-                (org-window-habit-normalize-time-to-duration
-                 (org-window-habit-time-max
-                  now
-                  (org-window-habit-keyed-duration-add-plist
-                   (aref done-times 0)
-                   reschedule-interval))
-                 reschedule-assessment-interval)
-                for iterators =
-                (cl-loop for window-spec in window-specs
-                         collect
-                         (org-window-habit-iterator-from-time
-                          window-spec candidate-time))
-                for conforming-values =
-                (cl-loop for iterator in iterators
-                         collect
-                         (org-window-habit-get-conforming-value iterator))
-                for assessment-value =
-                (funcall aggregation-fn conforming-values)
-                until (< assessment-value reschedule-threshold)
-                do (setq candidate-time
-                         (org-window-habit-keyed-duration-add-plist
-                          candidate-time
-                          reschedule-assessment-interval))
-                finally return candidate-time)
-             (org-window-habit-normalize-time-to-duration
-              now reschedule-assessment-interval))))
-      ;; Snap to next allowed reschedule day
-      (org-window-habit-next-allowed-day
-       raw-result
-       (org-window-habit-effective-reschedule-days
-        only-days reschedule-days)))))
+  (let ((active-habit (org-window-habit-for-time habit now)))
+    (when active-habit
+      (with-slots (reschedule-interval reschedule-assessment-interval done-times)
+          active-habit
+        (let* ((latest-done-time
+               (cl-loop for done-time across done-times
+                         when (org-window-habit-time-less-or-equal-p
+                               done-time now)
+                         return done-time))
+               (candidate-time
+                (if latest-done-time
+                    (org-window-habit-normalize-time-to-duration
+                     (org-window-habit-time-max
+                      now
+                      (org-window-habit-keyed-duration-add-plist
+                       latest-done-time reschedule-interval))
+                     reschedule-assessment-interval)
+                  (org-window-habit-normalize-time-to-duration
+                   now reschedule-assessment-interval)))
+              result)
+          (while (and (null result) candidate-time)
+            (let ((candidate-habit
+                   (org-window-habit-for-time habit candidate-time)))
+              (if (null candidate-habit)
+                  (setq candidate-time nil)
+                (with-slots
+                    (window-specs reschedule-threshold
+                                  reschedule-assessment-interval aggregation-fn
+                                  only-days reschedule-days)
+                    candidate-habit
+                  (let* ((iterators
+                          (cl-loop for window-spec in window-specs
+                                   collect
+                                   (org-window-habit-iterator-from-time
+                                    window-spec candidate-time)))
+                         (conforming-values
+                          (cl-loop for iterator in iterators
+                                   collect
+                                   (org-window-habit-get-conforming-value iterator)))
+                         (assessment-value
+                          (funcall aggregation-fn conforming-values)))
+                    (if (< assessment-value reschedule-threshold)
+                        (let ((allowed-time
+                               (org-window-habit-next-allowed-day
+                                candidate-time
+                                (org-window-habit-effective-reschedule-days
+                                 only-days reschedule-days))))
+                          (when (eq (oref candidate-habit active-config)
+                                    (org-window-habit-get-config-for-time
+                                     (oref habit configs) allowed-time))
+                            (setq result allowed-time))
+                          (unless result
+                            (setq candidate-time nil)))
+                      (setq candidate-time
+                            (org-window-habit-keyed-duration-add-plist
+                             candidate-time
+                             reschedule-assessment-interval))))))))
+          result)))))
 
 (cl-defmethod org-window-habit-get-future-required-intervals
   ((habit org-window-habit) count &optional now)
@@ -350,50 +376,63 @@ Each interval is computed by:
 This enables prospective planning: showing future \"must complete by\" dates
 assuming you complete at the last possible moment each time."
   (setq now (or now (current-time)))
-  (with-slots (window-specs assessment-interval reschedule-assessment-interval
-                            reschedule-interval reschedule-threshold
-                            max-repetitions-per-interval aggregation-fn only-days
-                            reschedule-days start-time)
-      habit
-    (let ((result '())
-          ;; Copy done-times to a list we can extend with simulated completions
-          (simulated-done-times (append (oref habit done-times) nil)))
-      (cl-loop
-       repeat count
-       do
-       ;; Create deep copies of window-specs to avoid mutation of original habit
-       ;; (initialize-instance sets the habit back-reference on each spec)
-       (let* ((copied-specs
-               (cl-loop for spec in window-specs
-                        collect (make-instance 'org-window-habit-window-spec
-                                               :duration (oref spec duration-plist)
-                                               :repetitions (oref spec target-repetitions)
-                                               :value (oref spec conforming-value)
-                                               :find-window (oref spec find-window))))
-              (temp-habit (make-instance 'org-window-habit
-                                         :window-specs copied-specs
-                                         :assessment-interval assessment-interval
-                                         :reschedule-assessment-interval
-                                         reschedule-assessment-interval
-                                         :reschedule-interval reschedule-interval
-                                         :reschedule-threshold reschedule-threshold
-                                         :max-repetitions-per-interval max-repetitions-per-interval
-                                         :aggregation-fn aggregation-fn
-                                         :only-days only-days
-                                         :reschedule-days reschedule-days
-                                         :done-times (vconcat
-                                                      (sort (copy-sequence simulated-done-times)
-                                                            (lambda (a b) (time-less-p b a))))
-                                         :start-time start-time))
-              (next-required (org-window-habit-get-next-required-interval temp-habit now)))
-         ;; Add to results
-         (push next-required result)
-         ;; Simulate completion at this time for next iteration
-         (push next-required simulated-done-times)
-         ;; Update now to be after the simulated completion
-         (setq now next-required)))
-      ;; Return in chronological order
-      (nreverse result))))
+  (let ((active-habit (org-window-habit-for-time habit now)))
+    (if (null active-habit)
+        nil
+      (unless (eq active-habit habit)
+        (setq habit active-habit))
+      (with-slots (window-specs assessment-interval reschedule-assessment-interval
+                  reschedule-interval reschedule-threshold
+                  max-repetitions-per-interval aggregation-fn only-days
+                  reschedule-days start-time configs active-config
+                  graph-assessment-fn)
+          habit
+        (let ((result '())
+              (simulated-done-times (append (oref habit done-times) nil)))
+          (cl-loop
+           repeat count
+           while now
+           do
+           (let* ((copied-specs
+                   (cl-loop
+                    for spec in window-specs
+                    collect
+                    (make-instance
+                     'org-window-habit-window-spec
+                     :duration (oref spec duration-plist)
+                     :repetitions (oref spec target-repetitions)
+                     :value (oref spec conforming-value)
+                     :find-window (oref spec find-window))))
+                  (temp-habit
+                   (make-instance
+                    'org-window-habit
+                    :window-specs copied-specs
+                    :assessment-interval assessment-interval
+                    :reschedule-assessment-interval
+                    reschedule-assessment-interval
+                    :reschedule-interval reschedule-interval
+                    :reschedule-threshold reschedule-threshold
+                    :max-repetitions-per-interval
+                    max-repetitions-per-interval
+                    :aggregation-fn aggregation-fn
+                    :only-days only-days
+                    :reschedule-days reschedule-days
+                    :configs configs
+                    :active-config active-config
+                    :graph-assessment-fn graph-assessment-fn
+                    :done-times
+                    (vconcat
+                     (sort (copy-sequence simulated-done-times)
+                           (lambda (a b) (time-less-p b a))))
+                    :start-time start-time))
+                  (next-required
+                   (org-window-habit-get-next-required-interval
+                    temp-habit now)))
+             (when next-required
+               (push next-required result)
+               (push next-required simulated-done-times))
+             (setq now next-required)))
+          (nreverse result))))))
 
 
 ;;; Assessment functions
@@ -414,33 +453,46 @@ TIME defaults to current time.
 Returns an alist with:
   - windowSpecsStatus: list of per-spec status with conformingRatio,
     completionsInWindow, targetRepetitions, duration, and conformingValue
-  - aggregatedConformingRatio: the overall conforming ratio after aggregation"
+  - aggregatedConformingRatio: the overall conforming ratio after aggregation
+Return nil when HABIT is inactive at TIME."
   (setq time (or time (current-time)))
-  (with-slots (window-specs aggregation-fn) habit
-    (let* ((iterators (cl-loop for spec in window-specs
-                               collect (org-window-habit-iterator-from-time spec time)))
-           (per-spec-data
-            (cl-loop for iterator in iterators
-                     for spec = (oref iterator window-spec)
-                     for window = (oref iterator window)
-                     for conforming-ratio = (org-window-habit-conforming-ratio iterator)
-                     for start-index = (oref iterator start-index)
-                     for end-index = (oref iterator end-index)
-                     for completions = (- end-index start-index)
-                     collect `(("conformingRatio" . ,conforming-ratio)
-                               ("completionsInWindow" . ,completions)
-                               ("targetRepetitions" . ,(oref spec target-repetitions))
-                               ("duration" . ,(oref spec duration-plist))
-                               ("conformingValue" . ,(oref spec conforming-value))
-                               ("windowStart" . ,(oref window start-time))
-                               ("windowEnd" . ,(oref window end-time)))))
-           (conforming-values
-            (cl-loop for iterator in iterators
-                     collect (org-window-habit-get-conforming-value iterator)))
-           (aggregated-ratio (or (funcall aggregation-fn conforming-values) 0.0)))
-      `(("windowSpecsStatus" . ,per-spec-data)
-        ("aggregatedConformingRatio" . ,aggregated-ratio)
-        ("conformingStreak" . ,(org-window-habit-current-streak habit time))))))
+  (let ((active-habit (org-window-habit-for-time habit time)))
+    (when active-habit
+      (unless (eq active-habit habit)
+        (setq habit active-habit))
+      (with-slots (window-specs aggregation-fn) habit
+        (let* ((iterators
+                (cl-loop for spec in window-specs
+                         collect
+                         (org-window-habit-iterator-from-time spec time)))
+               (per-spec-data
+                (cl-loop
+                 for iterator in iterators
+                 for spec = (oref iterator window-spec)
+                 for window = (oref iterator window)
+                 for conforming-ratio =
+                 (org-window-habit-conforming-ratio iterator)
+                 for start-index = (oref iterator start-index)
+                 for end-index = (oref iterator end-index)
+                 for completions = (- end-index start-index)
+                 collect `(("conformingRatio" . ,conforming-ratio)
+                           ("completionsInWindow" . ,completions)
+                           ("targetRepetitions" .
+                                                ,(oref spec target-repetitions))
+                           ("duration" . ,(oref spec duration-plist))
+                           ("conformingValue" . ,(oref spec conforming-value))
+                           ("windowStart" . ,(oref window start-time))
+                           ("windowEnd" . ,(oref window end-time)))))
+               (conforming-values
+                (cl-loop for iterator in iterators
+                         collect
+                         (org-window-habit-get-conforming-value iterator)))
+               (aggregated-ratio
+                (or (funcall aggregation-fn conforming-values) 0.0)))
+          `(("windowSpecsStatus" . ,per-spec-data)
+            ("aggregatedConformingRatio" . ,aggregated-ratio)
+            ("conformingStreak" .
+                                ,(org-window-habit-current-streak habit time))))))))
 
 (cl-defmethod org-window-habit-assess-interval-with-and-without-completions
   ((habit org-window-habit) iterators modify-completions-fn)

--- a/org-window-habit-core.el
+++ b/org-window-habit-core.el
@@ -132,7 +132,11 @@ Computed from earliest completion or reset-time if not specified.")
     :initarg :configs :initform nil
     :documentation "List of parsed versioned config plists with resolved dates.
 Each config plist contains :window-specs, :from, :until, and other habit parameters.
-Used for habits with evolving requirements over time."))
+Used for habits with evolving requirements over time.")
+   (active-config
+    :initarg :active-config :initform nil
+    :documentation "Config plist materialized into this instance's runtime slots.
+Nil is also used by manually constructed habits without versioned config data."))
   "A window-based habit with configurable evaluation windows and conformity tracking.")
 
 (defclass org-window-habit-window-spec ()
@@ -291,6 +295,73 @@ If there are no completions after reset, return nil."
 (cl-defmethod org-window-habit-has-any-done-times ((habit org-window-habit))
   "Return non-nil if HABIT has any recorded completions."
   (> (length (oref habit done-times)) 0))
+
+(defun org-window-habit--make-instance-for-config
+    (configs config done-times &optional time graph-assessment-fn)
+  "Materialize CONFIG from CONFIGS as a habit over DONE-TIMES.
+TIME defaults to the current time.  GRAPH-ASSESSMENT-FN, when non-nil,
+is preserved on the new instance."
+  (setq time (or time (current-time)))
+  (let* ((window-specs
+          (cl-loop for args in (plist-get config :window-specs)
+                   collect (apply #'make-instance
+                                  'org-window-habit-window-spec args)))
+         (assessment-interval
+          (org-window-habit-config-get-assessment-interval config))
+         (reset-time (plist-get config :from))
+         (start-time
+          (unless (or reset-time (> (length done-times) 0))
+            (org-window-habit-normalize-time-to-duration
+             time assessment-interval))))
+    (make-instance
+     'org-window-habit
+     :start-time start-time
+     :reset-time reset-time
+     :only-days (plist-get config :only-days)
+     :reschedule-days (plist-get config :reschedule-days)
+     :window-specs window-specs
+     :assessment-interval assessment-interval
+     :reschedule-assessment-interval
+     (org-window-habit-config-get-reschedule-assessment-interval config)
+     :aggregation-fn (or (plist-get config :aggregation-fn)
+                         'org-window-habit-default-aggregation-fn)
+     :reschedule-interval
+     (org-window-habit-config-get-reschedule-interval config)
+     :reschedule-threshold
+     (org-window-habit-config-get-reschedule-threshold config)
+     :done-times done-times
+     :max-repetitions-per-interval
+     (org-window-habit-config-get-max-reps-per-interval config)
+     :graph-assessment-fn graph-assessment-fn
+     :configs configs
+     :active-config config)))
+
+(cl-defmethod org-window-habit-active-at-time-p
+  ((habit org-window-habit) &optional time)
+  "Return non-nil when HABIT has an active config at TIME.
+TIME defaults to the current time.  Habits without config history are
+always active."
+  (or (null (oref habit configs))
+      (org-window-habit-get-config-for-time
+       (oref habit configs) (or time (current-time)))))
+
+(cl-defmethod org-window-habit-for-time
+  ((habit org-window-habit) &optional time)
+  "Return HABIT materialized with the config active at TIME.
+TIME defaults to the current time.  Return nil when TIME is outside every
+config range.  The original instance is returned when it already represents
+the selected config."
+  (setq time (or time (current-time)))
+  (if (null (oref habit configs))
+      habit
+    (let ((config (org-window-habit-get-config-for-time
+                   (oref habit configs) time)))
+      (when config
+        (if (eq config (oref habit active-config))
+            habit
+          (org-window-habit--make-instance-for-config
+           (oref habit configs) config (oref habit done-times)
+           time (oref habit graph-assessment-fn)))))))
 
 
 ;;; Window spec methods

--- a/org-window-habit-graph.el
+++ b/org-window-habit-graph.el
@@ -116,9 +116,10 @@ Returns (character face) or a list of such pairs for the present interval."
           (< without-completion-assessment-value with-completion-assessment-value))
          (next-required-interval (org-window-habit-get-next-required-interval habit))
          (completion-expected-today
-          (org-window-habit-time-falls-in-assessment-interval
-           window
-           next-required-interval))
+          (and next-required-interval
+               (org-window-habit-time-falls-in-assessment-interval
+                window
+                next-required-interval)))
          (interval-has-completion (> completions-in-interval 0)))
     (pcase current-interval-time-type
       ('present
@@ -178,9 +179,16 @@ Returns (character face) or a list of such pairs for the present interval."
 Returns a list of (character face) pairs for each interval:
 - Past intervals showing historical conformity
 - Present interval showing current status
-- Future intervals projecting expected conformity"
+- Future intervals projecting expected conformity
+Return nil when HABIT is inactive at NOW."
   (setq now (or now (current-time)))
-  (with-slots
+  (let ((active-habit (org-window-habit-for-time habit now)))
+    (cond
+     ((null active-habit) nil)
+     ((not (eq active-habit habit))
+      (org-window-habit-build-graph active-habit now))
+     (t
+      (with-slots
       (assessment-decrement-plist window-specs reschedule-interval
                                   max-repetitions-per-interval start-time aggregation-fn
                                   assessment-interval graph-assessment-fn)
@@ -273,7 +281,7 @@ Returns a list of (character face) pairs for each interval:
                     completion-in-interval-count
                     'future
                     habit
-                    (oref (car iterators) window))))))))))
+                    (oref (car iterators) window)))))))))))))
 
 
 ;;; Graph rendering
@@ -293,11 +301,11 @@ GRAPH-INFO is a list of (character face) pairs."
 
 (defun org-window-habit-streak-string (habit &optional now)
   "Return the configured streak display string for HABIT as of NOW."
-  (if org-window-habit-show-streak
-      (format org-window-habit-streak-format
-              (org-window-habit-current-streak
-               habit now org-window-habit-streak-threshold))
-    ""))
+  (let ((streak (org-window-habit-current-streak
+                 habit now org-window-habit-streak-threshold)))
+    (if (and org-window-habit-show-streak streak)
+        (format org-window-habit-streak-format streak)
+      "")))
 
 (defun org-window-habit-make-graph-display-string (habit &optional now)
   "Return HABIT's graph string with optional streak display as of NOW."

--- a/org-window-habit-instance.el
+++ b/org-window-habit-instance.el
@@ -40,11 +40,12 @@
 
 ;;; Instance creation from org entry
 
-(defun org-window-habit-create-instance-from-heading-at-point ()
+(defun org-window-habit-create-instance-from-heading-at-point (&optional time)
   "Construct an instance of class `org-window-habit' from the current org entry.
 Checks for CONFIG property first (unified format), then falls back to
 scattered properties (WINDOW_DURATION, WINDOW_SPECS, etc.) for backwards
-compatibility."
+compatibility.  TIME defaults to the current time.  Return nil when the
+entry's config is inactive at TIME."
   (save-excursion
     (let* ((done-times
             (sort
@@ -56,56 +57,30 @@ compatibility."
            (config-str (org-entry-get nil (org-window-habit-property "CONFIG") t)))
       (if config-str
           ;; New CONFIG property format
-          (org-window-habit-create-instance-from-config config-str done-times-vector)
+          (org-window-habit-create-instance-from-config
+           config-str done-times-vector time)
         ;; Fall back to scattered properties
-        (org-window-habit-create-instance-from-scattered-properties done-times-vector)))))
+        (org-window-habit-create-instance-from-scattered-properties
+         done-times-vector time)))))
 
-(defun org-window-habit-create-instance-from-config (config-str done-times-vector)
+(defun org-window-habit-create-instance-from-config
+    (config-str done-times-vector &optional time)
   "Create habit instance from CONFIG-STR with DONE-TIMES-VECTOR.
-CONFIG-STR is the value of the CONFIG property (single or versioned config)."
+CONFIG-STR is the value of the CONFIG property (single or versioned config).
+TIME defaults to the current time.  Return nil when no config is active then."
   (let* ((configs (org-window-habit-parse-config config-str))
-         ;; Get current config (first in list) for active parameters
-         (current-config (car configs))
-         ;; Extract parameters from current config
-         (window-specs-data (plist-get current-config :window-specs))
-         (window-specs (cl-loop for args in window-specs-data
-                                collect (apply #'make-instance
-                                               'org-window-habit-window-spec args)))
-         (assessment-interval (or (plist-get current-config :assessment-interval)
-                                  '(:days 1)))
-         (reschedule-interval
-          (org-window-habit-config-get-reschedule-interval current-config))
-         (reschedule-assessment-interval
-          (org-window-habit-config-get-reschedule-assessment-interval
-           current-config))
-         (aggregation-fn (or (plist-get current-config :aggregation-fn)
-                             'org-window-habit-default-aggregation-fn))
-         (reschedule-threshold
-          (or (plist-get current-config :reschedule-threshold) 1.0))
-         (max-reps (or (plist-get current-config :max-reps-per-interval) 1))
-         (only-days (plist-get current-config :only-days))
-         (reschedule-days (plist-get current-config :reschedule-days))
-         ;; :from on single config acts like reset-time
-         (reset-time (plist-get current-config :from)))
-    (make-instance 'org-window-habit
-                   :start-time nil
-                   :reset-time reset-time
-                   :only-days only-days
-                   :reschedule-days reschedule-days
-                   :window-specs window-specs
-                   :assessment-interval assessment-interval
-                   :reschedule-assessment-interval reschedule-assessment-interval
-                   :aggregation-fn aggregation-fn
-                   :reschedule-interval reschedule-interval
-                   :reschedule-threshold reschedule-threshold
-                   :done-times done-times-vector
-                   :max-repetitions-per-interval max-reps
-                   :configs configs)))
+         (config (org-window-habit-get-config-for-time
+                  configs (or time (current-time)))))
+    (when config
+      (org-window-habit--make-instance-for-config
+       configs config done-times-vector time))))
 
-(defun org-window-habit-create-instance-from-scattered-properties (done-times-vector)
+(defun org-window-habit-create-instance-from-scattered-properties
+    (done-times-vector &optional time)
   "Create habit instance from scattered properties with DONE-TIMES-VECTOR.
 This is the backwards-compatible path for habits without CONFIG property.
-Also builds and stores a config plist in the configs slot for uniformity."
+Also builds and stores a config plist in the configs slot for uniformity.
+TIME defaults to the current time."
   (let* ((assessment-interval-str
           (org-entry-get nil (org-window-habit-property "ASSESSMENT_INTERVAL")))
          (assessment-interval
@@ -184,19 +159,22 @@ Also builds and stores a config plist in the configs slot for uniformity."
             (when reset-time
               (setq c (plist-put c :from reset-time)))
             c)))
-    (make-instance 'org-window-habit
-                   :start-time nil
-                   :reset-time reset-time
-                   :only-days only-days
-                   :reschedule-days reschedule-days
-                   :window-specs window-specs-objects
-                   :assessment-interval assessment-interval
-                   :reschedule-assessment-interval reschedule-assessment-interval
-                   :reschedule-interval reschedule-interval
-                   :reschedule-threshold reschedule-threshold
-                   :done-times done-times-vector
-                   :max-repetitions-per-interval max-repetitions-per-interval
-                   :configs (list config))))
+    (org-window-habit-for-time
+     (make-instance 'org-window-habit
+                    :start-time nil
+                    :reset-time reset-time
+                    :only-days only-days
+                    :reschedule-days reschedule-days
+                    :window-specs window-specs-objects
+                    :assessment-interval assessment-interval
+                    :reschedule-assessment-interval reschedule-assessment-interval
+                    :reschedule-interval reschedule-interval
+                    :reschedule-threshold reschedule-threshold
+                    :done-times done-times-vector
+                    :max-repetitions-per-interval max-repetitions-per-interval
+                    :configs (list config)
+                    :active-config config)
+     time)))
 
 (defun org-window-habit-build-window-specs-plists-from-properties ()
   "Build window-specs as plists from current heading's scattered properties.

--- a/org-window-habit-meta.el
+++ b/org-window-habit-meta.el
@@ -96,11 +96,15 @@ Returns sum(score_i * weight_i) / sum(weight_i)."
 
 ;;; Weight extraction
 
-(defun org-window-habit-get-weight-from-config (configs)
+(defun org-window-habit-get-weight-from-config (configs &optional time)
   "Extract :weight from CONFIGS, default `org-window-habit-default-weight'.
-CONFIGS is a list of parsed config plists (from a habit's configs slot)."
+CONFIGS is a list of parsed config plists (from a habit's configs slot).
+When TIME is non-nil, use the config active at that time."
   (if configs
-      (or (plist-get (car configs) :weight)
+      (or (plist-get (if time
+                         (org-window-habit-get-config-for-time configs time)
+                       (car configs))
+                     :weight)
           org-window-habit-default-weight)
     org-window-habit-default-weight))
 
@@ -140,6 +144,7 @@ MARKERS is a list of markers pointing to habit entries.
 AGGREGATION-FN is the function to combine scores (defaults to
 `org-window-habit-meta-aggregation-fn').
 TIME is the evaluation time (defaults to current time).
+Habits without an active config at TIME are omitted.
 
 Returns an alist with:
   - \"score\": the final aggregated score (0.0-1.0+)
@@ -160,17 +165,23 @@ Returns an alist with:
             (goto-char marker)
             (when (org-window-habit-entry-p)
               (let* ((title (org-get-heading t t t t))
-                     (habit (org-window-habit-create-instance-from-heading-at-point))
-                     (status (org-window-habit-get-window-specs-status habit time))
-                     (conforming-ratio (cdr (assoc "aggregatedConformingRatio" status)))
-                     (weight (org-window-habit-get-weight-from-config (oref habit configs))))
-                (push `(("marker" . ,marker)
-                        ("title" . ,title)
-                        ("weight" . ,weight)
-                        ("conformingRatio" . ,conforming-ratio)
-                        ("windowSpecsStatus" . ,status))
-                      habit-data)
-                (push (cons conforming-ratio weight) score-weight-pairs)))))))
+                     (habit (org-window-habit-create-instance-from-heading-at-point time)))
+                (when habit
+                  (let* ((status
+                          (org-window-habit-get-window-specs-status habit time))
+                         (conforming-ratio
+                          (cdr (assoc "aggregatedConformingRatio" status)))
+                         (weight
+                          (org-window-habit-get-weight-from-config
+                           (oref habit configs) time)))
+                    (push `(("marker" . ,marker)
+                            ("title" . ,title)
+                            ("weight" . ,weight)
+                            ("conformingRatio" . ,conforming-ratio)
+                            ("windowSpecsStatus" . ,status))
+                          habit-data)
+                    (push (cons conforming-ratio weight)
+                          score-weight-pairs)))))))))
     ;; Compute aggregate score
     (let ((score (if score-weight-pairs
                      (funcall aggregation-fn (nreverse score-weight-pairs))

--- a/test/org-window-habit-test.el
+++ b/test/org-window-habit-test.el
@@ -4015,6 +4015,97 @@ Using (:weeks 1) instead of (:days 7) for week boundaries."
       ;; Should return oldest config (2 repetitions)
       (should (equal (plist-get (car (plist-get result :window-specs)) :repetitions) 2)))))
 
+(ert-deftest owh-test-bounded-single-config-is-inactive-after-until ()
+  "A bounded single config must not produce current requirement data after :until."
+  (let* ((config-str
+          "(:until \"2025-03-01\" :window-specs ((:duration (:days 7) :repetitions 2)))")
+         (active-time (owh-test-make-time 2025 2 28 12))
+         (inactive-time (owh-test-make-time 2025 3 1))
+         (habit (org-window-habit-create-instance-from-config
+                 config-str
+                 (vector (owh-test-make-time 2025 2 27 10)
+                         (owh-test-make-time 2025 2 26 10))
+                 active-time))
+         (window (org-window-habit-get-assessment-window
+                  (car (oref habit window-specs)) inactive-time))
+         (graph-result
+          (org-window-habit-default-graph-assessment-fn
+           0.0 1.0 0 'present habit window)))
+    (should habit)
+    (should-not (org-window-habit-active-at-time-p habit inactive-time))
+    (should-not (org-window-habit-for-time habit inactive-time))
+    (should-not (org-window-habit-create-instance-from-config
+                 config-str [] inactive-time))
+    (should-not (org-window-habit-get-window-specs-status
+                 habit inactive-time))
+    (should-not (org-window-habit-current-streak habit inactive-time))
+    (should-not (org-window-habit-get-next-required-interval
+                 habit inactive-time))
+    (should-not (org-window-habit-build-graph habit inactive-time))
+    (should (equal (org-window-habit-make-graph-display-string
+                    habit inactive-time)
+                   ""))
+    (should-not (eq (car (nth 1 graph-result))
+                    org-window-habit-completion-needed-today-glyph))))
+
+(ert-deftest owh-test-versioned-config-gap-is-inactive ()
+  "Historical and resumed versions stay evaluable while their gap is inactive."
+  (let* ((config-str
+          "((:from \"2025-06-01\" :window-specs ((:duration (:days 7) :repetitions 5))) (:until \"2025-03-01\" :window-specs ((:duration (:days 7) :repetitions 2))))")
+         (historical-time (owh-test-make-time 2025 2 28 12))
+         (gap-time (owh-test-make-time 2025 4 15 12))
+         (resumed-time (owh-test-make-time 2025 6 15 12))
+         (habit (org-window-habit-create-instance-from-config
+                 config-str
+                 (vector (owh-test-make-time 2025 6 14 10)
+                         (owh-test-make-time 2025 2 27 10)
+                         (owh-test-make-time 2025 2 26 10))
+                 resumed-time))
+         (historical-status
+          (org-window-habit-get-window-specs-status habit historical-time))
+         (resumed-status
+          (org-window-habit-get-window-specs-status habit resumed-time)))
+    (should (= (cdr (assoc "targetRepetitions"
+                           (car (cdr (assoc "windowSpecsStatus"
+                                            historical-status)))))
+               2))
+    (should (>= (cdr (assoc "aggregatedConformingRatio"
+                            historical-status))
+                0.99))
+    (should-not (org-window-habit-active-at-time-p habit gap-time))
+    (should-not (org-window-habit-get-window-specs-status habit gap-time))
+    (should-not (org-window-habit-get-next-required-interval habit gap-time))
+    (should (= (cdr (assoc "targetRepetitions"
+                           (car (cdr (assoc "windowSpecsStatus"
+                                            resumed-status)))))
+               5))))
+
+(ert-deftest owh-test-runtime-config-boundaries-are-half-open ()
+  "Runtime selection treats :from as inclusive and :until as exclusive."
+  (let* ((boundary (owh-test-make-time 2025 6 1))
+         (before-boundary (time-subtract boundary (seconds-to-time 1)))
+         (config-str
+          "((:from \"2025-06-01\" :window-specs ((:duration (:days 7) :repetitions 5))) (:until \"2025-06-01\" :window-specs ((:duration (:days 7) :repetitions 2))))")
+         (before (org-window-habit-create-instance-from-config
+                  config-str [] before-boundary))
+         (at (org-window-habit-create-instance-from-config
+              config-str [] boundary)))
+    (should (= (oref (car (oref before window-specs)) target-repetitions) 2))
+    (should (= (oref (car (oref at window-specs)) target-repetitions) 5))))
+
+(ert-deftest owh-test-current-active-version-retains-requirement-computations ()
+  "An unbounded current version remains active and produces requirement data."
+  (let* ((time (owh-test-make-time 2025 7 15 12))
+         (habit
+          (org-window-habit-create-instance-from-config
+           "((:from \"2025-06-01\" :window-specs ((:duration (:days 7) :repetitions 3))) (:until \"2025-06-01\" :window-specs ((:duration (:days 7) :repetitions 1))))"
+           (vector (owh-test-make-time 2025 7 14 10))
+           time))
+         (status (org-window-habit-get-window-specs-status habit time)))
+    (should (org-window-habit-active-at-time-p habit time))
+    (should (numberp (cdr (assoc "aggregatedConformingRatio" status))))
+    (should (org-window-habit-get-next-required-interval habit time))))
+
 ;;; ---------------------------------------------------------------------------
 ;;; Versioned Config: Instance Creation and Backwards Compatibility Tests
 ;;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- materialize the CONFIG version active at the requested reference time
- represent gaps and expired bounded configs as inactive via `nil`, with `org-window-habit-active-at-time-p` and `org-window-habit-for-time` as explicit runtime APIs
- suppress inactive conformity, streak, next-required, graph reminder, auto-repeat, and meta-evaluation results
- preserve historical and resumed-version evaluation with half-open `[from, until)` boundaries

## Tests

- focused ERT regressions for bounded single configs, pause gaps, range boundaries, and active current versions
- full ERT suite: 276 tests passed
- `nix build --no-link .#checks.x86_64-linux.test .#checks.x86_64-linux.byte-compile .#checks.x86_64-linux.checkdoc .#checks.x86_64-linux.package-lint -L`
- `nix flake check -L`