### PR TITLE
Build habit graph strings without aset

### DIFF
--- a/org-window-habit-graph.el
+++ b/org-window-habit-graph.el
@@ -289,13 +289,12 @@ Return nil when HABIT is inactive at NOW."
 (defun org-window-habit-make-graph-string (graph-info)
   "Convert GRAPH-INFO into a propertized string for display.
 GRAPH-INFO is a list of (character face) pairs."
-  (let ((graph (make-string (length graph-info) ?\s)))
-    (cl-loop for (character face) in graph-info
+  ;; Build the string from the characters up front: `aset' into a
+  ;; `make-string' buffer rejects non-ASCII glyphs on Emacs 31.
+  (let ((graph (concat (mapcar #'car graph-info))))
+    (cl-loop for (_character face) in graph-info
              for index from 0
-             do
-             (progn
-               (aset graph index character)
-               (put-text-property index (1+ index) 'face face graph)))
+             do (put-text-property index (1+ index) 'face face graph))
     (put-text-property 0 (length graph) 'org-window-habit-graph t graph)
     graph))
 

--- a/test/org-window-habit-test.el
+++ b/test/org-window-habit-test.el
@@ -1338,6 +1338,19 @@ This tests backwards compatibility - both old formats work."
   (let ((graph-info '((?x face1) (?y face2) (?z face3))))
     (should (= (length (org-window-habit-make-graph-string graph-info)) 3))))
 
+(ert-deftest owh-test-make-graph-string-non-ascii-glyphs ()
+  "Non-ASCII glyphs such as the default ✓ and ☐ must render with their faces."
+  (let* ((graph-info `((,org-window-habit-completed-glyph face1)
+                       (?\s face2)
+                       (,org-window-habit-completion-needed-today-glyph face3)))
+         (graph (org-window-habit-make-graph-string graph-info)))
+    (should (equal (substring-no-properties graph)
+                   (string org-window-habit-completed-glyph ?\s
+                           org-window-habit-completion-needed-today-glyph)))
+    (should (equal (mapcar (lambda (i) (get-text-property i 'face graph)) '(0 1 2))
+                   '(face1 face2 face3)))
+    (should (get-text-property 0 'org-window-habit-graph graph))))
+
 
 ;;; ==========================================================================
 ;;; Scenario-Based Tests: Real-World Habit Configurations


### PR DESCRIPTION
## Problem

`org-window-habit-make-graph-string` allocated its buffer with `make-string`, which returns a **unibyte** string, then wrote the glyphs in with `aset`. Emacs 30 silently widened the string to multibyte on the first non-ASCII store. Emacs 31 does not, and signals:

```
Attempt to store non-byte value into unibyte string
```

Since the default glyphs are `✓` (`org-window-habit-completed-glyph`) and `☐` (`org-window-habit-completion-needed-today-glyph`), this breaks habit rendering outright on Emacs 31. It took down every `/agenda` request on a deployed org-agenda-api instance as soon as its container picked up Emacs 31.1.

Passing the multibyte flag to `make-string` is not a fix either: Emacs 31 also rejects an `aset` that changes a character's byte length.

## Fix

Build the string from the glyphs with `concat` up front, then attach the face properties. No in-place character mutation.

## Testing

`nix flake check` (byte-compile, checkdoc, package-lint, 277 ERT tests) passes against both Emacs 30.2 and Emacs 31.1. Added `owh-test-make-graph-string-non-ascii-glyphs`, which fails on the old implementation under Emacs 31 and asserts the glyphs, per-character faces, and the graph text property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)